### PR TITLE
use i16 instead of i64 for offsets

### DIFF
--- a/src/instruction/linked.rs
+++ b/src/instruction/linked.rs
@@ -2,7 +2,10 @@ use std::slice::Iter;
 
 use super::{Instruction, LinkedInstructions};
 
-/// Take 8 bytes from an iterator to make 64 bit values
+/// Take 2 bytes from an iterator to make 16 bit values
+fn take2(i: &mut Iter<u8>) -> [u8; 2] { [*i.next().unwrap(), *i.next().unwrap()] }
+
+/// Take 8 bytes from an iterator to make 16 bit values
 fn take8(i: &mut Iter<u8>) -> [u8; 8] {
 	[
 		*i.next().unwrap(),
@@ -35,15 +38,15 @@ impl LinkedInstructions {
 		while let Some(b) = byte_iter.next() {
 			let inst = match b {
 				0 => {
-					let amt_parts = take8(&mut byte_iter);
-					let amount = i64::from_be_bytes(amt_parts);
+					let amt_parts = take2(&mut byte_iter);
+					let amount = i16::from_be_bytes(amt_parts);
 
 					Instruction::IncrDp { amount }
 				},
 				1 => {
 					let amount = *byte_iter.next().unwrap() as i8;
-					let ofst_parts = take8(&mut byte_iter);
-					let offset = i64::from_be_bytes(ofst_parts);
+					let ofst_parts = take2(&mut byte_iter);
+					let offset = i16::from_be_bytes(ofst_parts);
 
 					Instruction::Incr { amount, offset }
 				},
@@ -63,15 +66,15 @@ impl LinkedInstructions {
 				5 => Instruction::Write,
 				6 => {
 					let amount = *byte_iter.next().unwrap() as i8;
-					let ofst_parts = take8(&mut byte_iter);
-					let offset = i64::from_be_bytes(ofst_parts);
+					let ofst_parts = take2(&mut byte_iter);
+					let offset = i16::from_be_bytes(ofst_parts);
 
 					Instruction::Set { amount, offset }
 				},
 				7 => {
 					let amount = *byte_iter.next().unwrap() as i8;
-					let ofst_parts = take8(&mut byte_iter);
-					let offset = i64::from_be_bytes(ofst_parts);
+					let ofst_parts = take2(&mut byte_iter);
+					let offset = i16::from_be_bytes(ofst_parts);
 
 					Instruction::Mul { amount, offset }
 				},

--- a/src/instruction/mod.rs
+++ b/src/instruction/mod.rs
@@ -57,16 +57,16 @@ pub type Cell = i8;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Instruction {
-	IncrDp { amount: i64 },
-	Incr { amount: Cell, offset: i64 },
+	IncrDp { amount: i16 },
+	Incr { amount: Cell, offset: i16 },
 	BranchIfZero { destination: u64 },
 	BranchIfNotZero { destination: u64 },
 	Read,
 	Write,
 
 	// The following instructions are IR-only, the have no direct BF equivalent
-	Set { amount: Cell, offset: i64 },
-	Mul { amount: Cell, offset: i64 },
+	Set { amount: Cell, offset: i16 },
+	Mul { amount: Cell, offset: i16 },
 }
 
 impl fmt::Display for Instruction {
@@ -92,14 +92,14 @@ impl Instruction {
 		match self {
 			Self::IncrDp { amount } => {
 				let mut inst_bytes = vec![0];
-				let amt_parts: [u8; 8] = amount.to_be_bytes();
+				let amt_parts: [u8; 2] = amount.to_be_bytes();
 				inst_bytes.extend_from_slice(&amt_parts);
 
 				inst_bytes
 			},
 			Self::Incr { amount, offset } => {
 				let mut inst_bytes = vec![1, *amount as u8];
-				let ofst_parts: [u8; 8] = offset.to_be_bytes();
+				let ofst_parts: [u8; 2] = offset.to_be_bytes();
 				inst_bytes.extend_from_slice(&ofst_parts);
 
 				inst_bytes
@@ -126,14 +126,14 @@ impl Instruction {
 			},
 			Self::Set { amount, offset } => {
 				let mut inst_bytes = vec![6, *amount as u8];
-				let ofst_parts: [u8; 8] = offset.to_be_bytes();
+				let ofst_parts: [u8; 2] = offset.to_be_bytes();
 				inst_bytes.extend_from_slice(&ofst_parts);
 
 				inst_bytes
 			},
 			Self::Mul { amount, offset } => {
 				let mut inst_bytes = vec![7, *amount as u8];
-				let ofst_parts: [u8; 8] = offset.to_be_bytes();
+				let ofst_parts: [u8; 2] = offset.to_be_bytes();
 				inst_bytes.extend_from_slice(&ofst_parts);
 
 				inst_bytes

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -7,7 +7,7 @@ const MEM_SIZE: usize = 65536;
 
 pub struct Interpreter<'i> {
 	ip:     usize,
-	dp:     usize,
+	dp:     u16,
 	memory: [u8; MEM_SIZE],
 	insts:  &'i [Instruction],
 }
@@ -25,13 +25,13 @@ impl<'i> Interpreter<'i> {
 		while self.ip < self.insts.len() {
 			match self.insts[self.ip] {
 				Instruction::IncrDp { amount } => {
-					self.dp = (self.dp + amount as usize) % MEM_SIZE;
+					self.dp += amount as u16;
 				},
 				Instruction::Incr { amount, offset } => {
-					self.memory[(self.dp + offset as usize).rem_euclid(MEM_SIZE)] += amount as u8;
+					self.memory[(self.dp + offset as u16) as usize] += amount as u8;
 				},
 				Instruction::Write => {
-					writer.write_all(&[self.memory[self.dp]])?;
+					writer.write_all(&[self.memory[self.dp as usize]])?;
 				},
 				Instruction::Read => {
 					writer.flush()?;
@@ -39,29 +39,29 @@ impl<'i> Interpreter<'i> {
 					let bytes = reader.read(&mut buffer)?;
 
 					if bytes == 1 {
-						self.memory[self.dp] = buffer[0];
+						self.memory[self.dp as usize] = buffer[0];
 					} else {
 						return Err(Error::CouldNotReadInput);
 					}
 				},
 				Instruction::BranchIfZero { destination } => {
-					if self.memory[self.dp] == 0 {
+					if self.memory[self.dp as usize] == 0 {
 						self.ip = destination as usize;
 						continue;
 					}
 				},
 				Instruction::BranchIfNotZero { destination } => {
-					if self.memory[self.dp] != 0 {
+					if self.memory[self.dp as usize] != 0 {
 						self.ip = destination as usize;
 						continue;
 					}
 				},
 				Instruction::Set { amount, offset } => {
-					self.memory[(self.dp + offset as usize).rem_euclid(MEM_SIZE)] = amount as u8;
+					self.memory[(self.dp + offset as u16) as usize] = amount as u8;
 				},
 				Instruction::Mul { amount, offset } => {
-					self.memory[(self.dp + offset as usize).rem_euclid(MEM_SIZE)] +=
-						self.memory[self.dp] * amount as u8
+					self.memory[(self.dp + offset as u16) as usize] +=
+						self.memory[self.dp as usize] * amount as u8
 				},
 			}
 

--- a/src/optimise.rs
+++ b/src/optimise.rs
@@ -255,7 +255,7 @@ fn order_hmap_values<K: Ord + Hash + Eq, V>(map: HashMap<K, V>) -> Vec<V> {
 /// so there's only a single IncrIp
 fn reorder_sequence(insts: &[Instruction]) -> Vec<Instruction> {
 	// Keeps track of instructions with the same offset
-	let mut insts_by_offset: HashMap<i64, Vec<Instruction>> = HashMap::new();
+	let mut insts_by_offset: HashMap<i16, Vec<Instruction>> = HashMap::new();
 	// Keeps track of the current offset as set by IncrIp instructions
 	let mut current_offset = 0;
 
@@ -297,7 +297,7 @@ fn reorder_sequence(insts: &[Instruction]) -> Vec<Instruction> {
 /// Check if a series of instructions matches the multiply loop pattern
 ///
 /// If it is, return the cells that are affected
-fn is_multiply_loop(insts: &[Instruction]) -> Option<HashMap<i64, Cell>> {
+fn is_multiply_loop(insts: &[Instruction]) -> Option<HashMap<i16, Cell>> {
 	let mut net_movement = 0;
 
 	// Multiply loops can only contain Incr and IncrIp instructions
@@ -332,7 +332,7 @@ fn is_multiply_loop(insts: &[Instruction]) -> Option<HashMap<i64, Cell>> {
 /// Return a hashmap of all the cells that are affected by this
 /// sequence of instructions, and how much they change.
 /// E.g. "->>+++>+" -> {0: -1, 2: 3, 3: 1}
-fn cell_changes(insts: &[Instruction]) -> HashMap<i64, Cell> {
+fn cell_changes(insts: &[Instruction]) -> HashMap<i16, Cell> {
 	let mut changes = HashMap::new();
 	let mut cell_index = 0;
 


### PR DESCRIPTION
this removes the need for expensive modulo calculations when indexing the interpreters memory